### PR TITLE
Changing to 50 branches as the api fails at 100

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8734,7 +8734,7 @@ async function cascadingBranchMerge (
   const branches = await octokit.paginate(octokit.rest.repos.listBranches, {
     owner: repository.owner,
     repo: repository.repo,
-    per_page: 100
+    per_page: 50
   },
   response => response.data
   )

--- a/src/cascading-branch-merge.js
+++ b/src/cascading-branch-merge.js
@@ -38,7 +38,7 @@ async function cascadingBranchMerge (
   const branches = await octokit.paginate(octokit.rest.repos.listBranches, {
     owner: repository.owner,
     repo: repository.repo,
-    per_page: 100
+    per_page: 50
   },
   response => response.data
   )

--- a/test/cascading-branch-merge-test.js
+++ b/test/cascading-branch-merge-test.js
@@ -63,7 +63,7 @@ describe('Cascade branch merge test', () => {
       {
         owner: 'ActionsDesk',
         repo: 'hello-world',
-        per_page: 100
+        per_page: 50
       },
       expect.anything()
     )
@@ -135,7 +135,7 @@ describe('Cascade branch merge test', () => {
       {
         owner: 'ActionsDesk',
         repo: 'hello-world',
-        per_page: 100
+        per_page: 50
       },
       expect.anything()
     )


### PR DESCRIPTION
Adding more context to this PR. @jonweeks opened a ticket with GH https://support.github.com/ticket/personal/0/2469390 because the API to list branches with page size set to 100 is timing out and getting a 504 with 
```json
{
    "message": "We couldn't respond to your request in time. Sorry about that. Please try resubmitting your request and contact us if the problem persists."
}
```

This changes our list branches octokit call to only get 50 per API call but will still do pagination. So for example, if there were 200 branches in a project before that would be 2 API calls now it is 4.