### PR TITLE
update the README to show how to use this exactly  like BitBickets auto-merge feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Repository.
 | release/2.0.1-beta   |
 | release/2.0.1-beta.1 |
 
-A developer creates a new branch from the `release/1.1` branch, makes their change. and issues a pull request
+A developer creates a new branch from the `release/1.1` branch, makes their change, and issues a pull request
 (PR) against the `release/1.1` branch, requesting at least one approval. The
 following should happen when the PR is approved:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A developer creates a new branch from the `release/1.1` branch, makes their chan
 (PR) against the `release/1.1` branch, requesting at least one approval. The
 following should happen when the PR is approved:
 
-1. The developers branch is merged into `release/1.1`
+1. The developer's branch is merged into `release/1.1`
 1. `release/1.1` is merged into all **subsequent** releases based on their
    semantic version
 1. After the last branch named with a semantic version has been merged, the change is also merged to the `development` branch

--- a/README.md
+++ b/README.md
@@ -35,14 +35,16 @@ Repository.
 | release/2.0.1-beta   |
 | release/2.0.1-beta.1 |
 
-A developer creates a new branch from the `release/1.1` branch, makes their change, and issues a pull request
-(PR) against the `release/1.1` branch, requesting at least one approval. The
-following should happen when the PR is approved:
+A developer creates a new branch from the `release/1.1` branch, makes their
+change, and issues a pull request (PR) against the `release/1.1` branch,
+requesting at least one approval. The following should happen when the PR is
+approved:
 
 1. The developer's branch is merged into `release/1.1`
 1. `release/1.1` is merged into all **subsequent** releases based on their
    semantic version
-1. After the last branch named with a semantic version has been merged, the change is also merged to the `development` branch
+1. After the last branch named with a semantic version has been merged, the
+   change is also merged to the `development` branch
 
 This sample output should demonstrate the expected GitHub behaviour:
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ Repository.
 | release/2.0.1-beta   |
 | release/2.0.1-beta.1 |
 
-A developer makes a change to the `release/1.1` branch and issues a pull request
-(PR) against the `development` branch, requesting at least one approval. The
+A developer creates a new branch from the `release/1.1` branch, makes their change. and issues a pull request
+(PR) against the `release/1.1` branch, requesting at least one approval. The
 following should happen when the PR is approved:
 
-1. `release/1.1` is merged into `development`
+1. The developers branch is merged into `release/1.1`
 1. `release/1.1` is merged into all **subsequent** releases based on their
    semantic version
+1. After the last branch named with a semantic version has been merged, the change is also merged to the `development` branch
 
 This sample output should demonstrate the expected GitHub behaviour:
 
@@ -156,7 +157,7 @@ jobs:
 
     if: |
       github.event.pull_request.merged == true &&
-      startsWith(github.head_ref, 'release/')
+      startsWith(github.base_ref, 'release/')
 
     steps:
       - name: Automatic Merge
@@ -207,7 +208,7 @@ jobs:
 
     if: |
       github.event.pull_request.merged == true &&
-      startsWith(github.head_ref, 'release/')
+      startsWith(github.base_ref, 'release/')
 
     steps:
       - name: Get GitHub App Token


### PR DESCRIPTION
Currently the README says...

"A developer makes a change to the release/1.1 branch and issues a pull request (PR) against the development branch, requesting at least one approval. The following should happen when the PR is approved:

1. release/1.1 is merged into development
1. release/1.1 is merged into all subsequent releases based on their semantic version"

This is not ideal, because normally you would have branch protection on `release/1.1` branch and only allow change to merge into it via a PR. This change updates this section of the README to...

"A developer creates a new branch from the `release/1.1` branch, makes their change. and issues a pull request
(PR) against the `release/1.1` branch, requesting at least one approval. The
following should happen when the PR is approved:

1. The developers branch is merged into `release/1.1`
1. `release/1.1` is merged into all **subsequent** releases based on their
   semantic version
1. After the last branch named with a semantic version has been merged, the change is also merged to the `development` branch"

This is a better workflow, and one that is more likely to be found among users. This change also updates the example workflow configurations to show the following if statment:
```yaml
    if: |
      github.event.pull_request.merged == true &&
      startsWith(github.base_ref, 'release/')
```

Referencing `github.base_ref` instead of `github.head_ref` means that this job runs if the PR was merged into a `release/*` branch.